### PR TITLE
feat(profile): add Years of Experience (YOE) to onboarding

### DIFF
--- a/Controllers/Add_Update_Profile.js
+++ b/Controllers/Add_Update_Profile.js
@@ -840,6 +840,7 @@ export default async function Add_Update_Profile(req, res) {
       undergraduateTranscript,
       preferredRoles,
       experienceLevel,
+      yearsOfExperience,
       expectedSalaryRange,
       expectedSalaryNarrative,
       preferredLocations,
@@ -925,6 +926,9 @@ export default async function Add_Update_Profile(req, res) {
           undergraduateTranscript: undergraduateTranscript || existingProfile.undergraduateTranscript,
           preferredRoles: preferredRoles || existingProfile.preferredRoles,
           experienceLevel: experienceLevel || existingProfile.experienceLevel,
+          yearsOfExperience: yearsOfExperience !== undefined && yearsOfExperience !== ""
+            ? Number(yearsOfExperience)
+            : existingProfile.yearsOfExperience,
           expectedSalaryRange: expectedSalaryRange || existingProfile.expectedSalaryRange,
           expectedSalaryNarrative: expectedSalaryNarrative !== undefined ? expectedSalaryNarrative : existingProfile.expectedSalaryNarrative,
           preferredLocations: preferredLocations || existingProfile.preferredLocations,
@@ -1003,6 +1007,9 @@ export default async function Add_Update_Profile(req, res) {
         undergraduateTranscript: undergraduateTranscript || existingProfile.undergraduateTranscript,
         preferredRoles: preferredRoles || existingProfile.preferredRoles,
         experienceLevel: experienceLevel || existingProfile.experienceLevel,
+        yearsOfExperience: yearsOfExperience !== undefined && yearsOfExperience !== ""
+          ? Number(yearsOfExperience)
+          : existingProfile.yearsOfExperience,
         expectedSalaryRange: expectedSalaryRange || existingProfile.expectedSalaryRange,
         expectedSalaryNarrative: expectedSalaryNarrative !== undefined ? expectedSalaryNarrative : existingProfile.expectedSalaryNarrative,
         preferredLocations: preferredLocations || existingProfile.preferredLocations,
@@ -1070,6 +1077,7 @@ export default async function Add_Update_Profile(req, res) {
         undergraduateTranscript: undergraduateTranscript || null,
         preferredRoles: preferredRoles || [],
         experienceLevel: experienceLevel || "",
+        yearsOfExperience: yearsOfExperience !== undefined && yearsOfExperience !== "" ? Number(yearsOfExperience) : null,
         expectedSalaryRange: expectedSalaryRange || "",
         expectedSalaryNarrative: expectedSalaryNarrative || "",
         preferredLocations: preferredLocations || [],

--- a/Schema_Models/ProfileModel.js
+++ b/Schema_Models/ProfileModel.js
@@ -318,6 +318,15 @@ export const profileSchema = new mongoose.Schema({
     ],
     required: true,
   },
+  // YOE — total years of professional experience (numeric). Optional; used
+  // by the scraper/AI to gauge seniority more precisely than the level label.
+  yearsOfExperience: {
+    type: Number,
+    required: false,
+    min: 0,
+    max: 60,
+    default: null,
+  },
   expectedSalaryRange: {
     type: String,
     enum: ["60k-100k", "100k-150k", "150k-200k", "Other"],


### PR DESCRIPTION
Adds a numeric YOE field alongside the experience-level label so the scraper and AI summary get a precise seniority signal for better job matching. Optional; persisted in create + both update paths.