### PR TITLE
fix: crash guards and fail-fast DB connect to stop intermittent network errors

### DIFF
--- a/Utils/ConnectDB.js
+++ b/Utils/ConnectDB.js
@@ -1,9 +1,18 @@
 import mongoose from "mongoose";
 import dotenv from 'dotenv'
 dotenv.config();
-//connection to db ..
-const Connection = () => mongoose.connect(process.env.MONGODB_URI)
+
+// Surface connection drops in the logs so outages are diagnosable from Render.
+mongoose.connection.on('disconnected', () => console.error('[mongo] connection lost'));
+mongoose.connection.on('reconnected', () => console.log('[mongo] reconnected'));
+
+// No .catch here on purpose: a failed initial connect must reject so index.js
+// logs it and exits — the platform then restarts the process. Swallowing the
+// error left a zombie server running with no database, answering 503 forever.
+const Connection = () => mongoose.connect(process.env.MONGODB_URI, {
+                              serverSelectionTimeoutMS: 10000,
+                              maxPoolSize: 20,
+                         })
                     .then(()=>console.log("Database connected succesfully..!"))
-                    .catch((e)=>console.log('Problem while connecting to db', e));
 
 export default Connection

--- a/index.js
+++ b/index.js
@@ -161,6 +161,20 @@ import { startAutoOptimizationWorker } from "./src/services/autoOptimizationWork
 
 dotenv.config();
 
+// A single stray promise rejection in any route or background worker must not
+// take the whole API down (Node >= 15 crashes the process by default). While
+// the process restarts, every client mid-request sees "Network error". Log
+// and keep serving instead.
+process.on("unhandledRejection", (reason) => {
+  console.error("[fatal-guard] Unhandled promise rejection:", reason);
+});
+// Synchronous throws leave undefined state — log, then exit so the platform
+// restarts us cleanly.
+process.on("uncaughtException", (err) => {
+  console.error("[fatal-guard] Uncaught exception, exiting for restart:", err);
+  process.exit(1);
+});
+
 const app = express();
 const PORT = process.env.PORT || 8086;
 const NODE_ENV = process.env.NODE_ENV || "development";


### PR DESCRIPTION
## Why

Clients intermittently hit "Network error" on login. Live diagnosis showed the production API healthy but vulnerable to short full outages:

1. Any unhandled promise rejection in any route or background worker kills the whole Node process (default on Node >= 18) — every client gets network errors while the platform restarts it.
2. `ConnectDB` swallowed the initial Mongo connect error: the server logged "connected successfully" with no database and served 503s until a manual restart.

## Changes

- `index.js`: `unhandledRejection` is logged and survived (`[fatal-guard]` tag in logs); `uncaughtException` logs then exits cleanly for a platform restart.
- `Utils/ConnectDB.js`: initial connect failure now rejects so startup exits and the platform restarts, instead of leaving a zombie server; adds `serverSelectionTimeoutMS: 10000`, `maxPoolSize: 20`, and `[mongo] connection lost/reconnected` log lines.

Verified with `node --check`; option names match Mongoose 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)