### PR TITLE
Add UK visa status options to Profile schema

### DIFF
--- a/Schema_Models/ProfileModel.js
+++ b/Schema_Models/ProfileModel.js
@@ -228,7 +228,7 @@ export const profileSchema = new mongoose.Schema({
   },
   visaStatus: {
     type: String,
-    enum: ["CPT", "F1", "F1 OPT", "F1 STEM OPT", "H1B", "Green Card", "U.S. Citizen", "Canadian Citizen", "Permanent Resident (PR)", "Post-Graduation Work Permit (PGWP)", "Open Work Permit (OWP)", "Employer-Specific (Closed) Work Permit", "Study Permit", "Other"],
+    enum: ["CPT", "F1", "F1 OPT", "F1 STEM OPT", "H1B", "Green Card", "U.S. Citizen", "Canadian Citizen", "Permanent Resident (PR)", "Post-Graduation Work Permit (PGWP)", "Open Work Permit (OWP)", "Employer-Specific (Closed) Work Permit", "Study Permit", "Student Visa", "Short-term Study Visa", "Graduate Visa", "Skilled Worker Visa", "Global Talent Visa", "Other"],
     required: true,
   },
   otherVisaType: {


### PR DESCRIPTION
## Summary
- Adds Student Visa, Short-term Study Visa, Graduate Visa, Skilled Worker Visa, and Global Talent Visa to the `visaStatus` enum on `ProfileModel`.
- Without this, submissions using the new options (added in the companion frontend PR) fail Mongoose enum validation and never save.

Companion frontend PR: support1122/flashfire-dashboard-frontend#126 — **merge this backend PR first or alongside it**, since the frontend dropdown will offer values the backend currently rejects.

## Test plan
- [ ] Submit onboarding form with each new visa value selected, confirm it saves (no 400/validation error).
- [ ] Confirm existing visa values still validate and save unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)